### PR TITLE
fix(package): update node entrypoint path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "glob-gitignore",
   "version": "1.0.7",
   "description": "Extends `glob` with support for filtering files according to gitignore rules and exposes an optional Promise API",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "module": "src/index.js",
   "scripts": {
     "test": "nyc ava --timeout=10s",


### PR DESCRIPTION
Hey there 👋 There's invalid `main` property in `package.json` in latest 1.0.8 release. Cheers!