### PR TITLE
dep: reduce size of consumer node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "glob": "^7.1.3",
     "ignore": "^5.0.5",
-    "lodash.difference": "^4.5.0",
-    "lodash.union": "^4.6.0",
+    "lodash": "4.x",
     "make-array": "^1.0.5",
     "util.inherits": "^1.0.3"
   }

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 const ignore = require('ignore')
 const path = require('path')
-const difference = require('lodash.difference')
-const union = require('lodash.union')
+const difference = require('lodash/difference')
+const union = require('lodash/union')
 const make_array = require('make-array')
 
 const IGNORE = typeof Symbol === 'function'


### PR DESCRIPTION
## Summary

Reduce size of users dependency tree

Most of users already has lodash installed as its a dependency of thousands of packages
When i look at mine, I see 50 different versions of submodules,

This is also recommended action from lodash: https://lodash.com/per-method-packages and per method packages will no longer be available in v5

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

